### PR TITLE
fix config syntax all  \Config::get("barcode::store_path")

### DIFF
--- a/src/Milon/Barcode/DNS1D.php
+++ b/src/Milon/Barcode/DNS1D.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Milon\Barcode;
 
@@ -126,7 +126,7 @@ class DNS1D {
      */
     public function getBarcodeHTML($code, $type, $w = 2, $h = 30, $color = 'black') {
         if (!$this->store_path) {
-            $this->setStorPath(\Config::get("barcode::store_path"));
+            $this->setStorPath(\Config::get("barcode.store_path"));
         }
         $this->setBarcode($code, $type);
         $html = '<div style="font-size:0;position:relative;">' . "\n";
@@ -159,7 +159,7 @@ class DNS1D {
      */
     public function getBarcodePNG($code, $type, $w = 2, $h = 30, $color = array(0, 0, 0)) {
         if (!$this->store_path) {
-            $this->setStorPath(\Config::get("barcode::store_path"));
+            $this->setStorPath(\Config::get("barcode.store_path"));
         }
         $this->setBarcode($code, $type);
         // calculate image size
@@ -226,7 +226,7 @@ class DNS1D {
      */
     public function getBarcodePNGPath($code, $type, $w = 2, $h = 30, $color = array(0, 0, 0)) {
         if (!$this->store_path) {
-            $this->setStorPath(\Config::get("barcode::store_path"));
+            $this->setStorPath(\Config::get("barcode.store_path"));
         }
         $this->setBarcode($code, $type);
         // calculate image size

--- a/src/Milon/Barcode/DNS2D.php
+++ b/src/Milon/Barcode/DNS2D.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Milon\Barcode;
 
@@ -141,7 +141,7 @@ class DNS2D {
      */
     public function getBarcodeHTML($code, $type, $w = 10, $h = 10, $color = 'black') {
         if (!$this->store_path) {
-            $this->setStorPath(\Config::get("barcode::store_path"));
+            $this->setStorPath(\Config::get("barcode.store_path"));
         }
         //set barcode code and type
         $this->setBarcode($code, $type);
@@ -181,7 +181,7 @@ class DNS2D {
      */
     public function getBarcodePNG($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {
         if (!$this->store_path) {
-            $this->setStorPath(\Config::get("barcode::store_path"));
+            $this->setStorPath(\Config::get("barcode.store_path"));
         }
         //set barcode code and type
         $this->setBarcode($code, $type);
@@ -271,7 +271,7 @@ class DNS2D {
      */
     public function getBarcodePNGPath($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {
         if (!$this->store_path) {
-            $this->setStorPath(\Config::get("barcode::store_path"));
+            $this->setStorPath(\Config::get("barcode.store_path"));
         }
         //set barcode code and type
         $this->setBarcode($code, $type);


### PR DESCRIPTION
Changing the syntax of all functions you use the \ Config :: get ("barcode :: store_path") to \ Config :: get ("barcode.store_path")