### PR TITLE
fix for generating upce barcode when passed with less than 6 digit value

### DIFF
--- a/src/Milon/Barcode/DNS1D.php
+++ b/src/Milon/Barcode/DNS1D.php
@@ -2388,6 +2388,13 @@ class DNS1D {
     protected function upce2a($code) {
         $manufacturer = '';
         $itemNumber = '';
+
+        if (strlen($code) > 6) {
+            $code = substr($code, -6);
+        } else {
+            $code = str_pad($code, 6, '0', STR_PAD_LEFT);
+        }
+
         // break digits
         $digit1 = substr($code, 0, 1);
         $digit2 = substr($code, 1, 1);


### PR DESCRIPTION
Changes:
* Add leading zeros if the code passed is less than 6 digits.
    e.g. `DNS1D::getBarcodeHTML(123, 'UPCE')` - barcode value will be `000123`

* Selecting the last 6 digits if the code passed is more than 6 digits.
    e.g. `DNS1D::getBarcodeHTML(123456789, 'UPCE')` - barcode value will be `456789`