### PR TITLE
Fix Uri returning the file’s physical path with app’s base url prepended

### DIFF
--- a/src/Milon/Barcode/DNS1D.php
+++ b/src/Milon/Barcode/DNS1D.php
@@ -303,7 +303,7 @@ class DNS1D {
      * @protected
      */
     protected function getBarcodePNGUri($code, $type, $w = 2, $h = 30, $color = array(0, 0, 0)) {
-        return url($this->getBarcodePNGPath($code, $type, $w, $h, $color));
+        return url(str_replace(base_path(), '', $this->getBarcodePNGPath($code, $type, $w, $h, $color)));
     }
 
     /**

--- a/src/Milon/Barcode/DNS2D.php
+++ b/src/Milon/Barcode/DNS2D.php
@@ -252,7 +252,7 @@ class DNS2D {
      * @protected
      */
     protected function getBarcodePNGUri($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {
-        return url($this->getBarcodePNGPath($code, $type, $w, $h, $color));
+        return url(str_replace(base_path(), '', $this->getBarcodePNGPath($code, $type, $w, $h, $color)));
     }
 
     /**


### PR DESCRIPTION
For example, a file being stored at `/var/www/site.com/public/storage/barcode/1234567890.png` would have a URI of `http://site.com/var/www/site.com/public/storage/barcode/1234567890.png` instead of the expected `http://site.com/storage/barcode/1234567890.png`.

Please note: this will not fix the URI for people who have set the `barcode.store_path` config value to something like `storage_path('app/public/barcode')`, only because it is technically outside of the webroot. I have not been able to find any way to translate Laravel's public storage path (or public disk) to it's symlinked public path. [More about the public disk here.](https://laravel.com/docs/5.4/filesystem#the-public-disk) (since Laravel ~5.2)