### PR TITLE
add Laravel Package Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,19 @@
             "Milon\\Barcode": "src/"
         }
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Milon\\Barcode\\BarcodeServiceProvider"
+            ],
+            "aliases": {
+                "DNS1D": "Milon\\Barcode\\Facades\\DNS1DFacade",
+                "DNS2D": "Milon\\Barcode\\Facades\\DNS2DFacade"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Laravel will automatically register its service providers and facades when it is installed, creating a convenient installation experience for your package's users.

https://laravel.com/docs/5.6/packages#package-discovery