### PR TITLE
DNS2D::getBarcodePNGUri() returns malformed URL (Windows)

### DIFF
--- a/src/Milon/Barcode/DNS2D.php
+++ b/src/Milon/Barcode/DNS2D.php
@@ -252,7 +252,9 @@ class DNS2D {
      * @protected
      */
     protected function getBarcodePNGUri($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {
-        return url($this->getBarcodePNGPath($code, $type, $w, $h, $color));
+        $path = $this->getBarcodePNGPath($code, $type, $w, $h, $color);
+        // Replace backslash (Windows) with forward slashes, to make it compatible with url().
+        return url(str_replace('\\', '/', $path));
     }
 
     /**


### PR DESCRIPTION
When calling `DNS2D::getBarcodePNGUri()` on Windows, a malformed URL will be returned.

```php
/**
 * src/Milon/Barcode/DNS2D.php:327
 */

return str_replace(public_path(), '', $save_file);

# public_path() = 'C:\FakePath\public';
# $save_file = 'C:\FakePath\public\barcodes/lorem-ipsum.png';
# return '\barcodes/lorem-ipsum.png';


/**
 * src/Milon/Barcode/DNS2D.php:255
 */

return url($this->getBarcodePNGPath($code, $type, $w, $h, $color));

# return 'http://example.com/\barcodes/lorem-ipsum.png';
```

I solved this by: 
```php
protected function getBarcodePNGUri($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {
    $path = $this->getBarcodePNGPath($code, $type, $w, $h, $color);
    // Replace backslash (Windows) with forward slashes, to make it compatible with url().
    return url(str_replace('\\', '/', $path));
}
```

A `return url(ltrim($path, '\\'));` will work too.
