### PR TITLE
Methods that will be available for external access must be declared as public

### DIFF
--- a/src/Milon/Barcode/DNS1D.php
+++ b/src/Milon/Barcode/DNS1D.php
@@ -85,7 +85,7 @@ class DNS1D {
      * @return string SVG code.
      * @protected
      */
-    protected function getBarcodeSVG($code, $type, $w = 2, $h = 30, $color = 'black', $showCode = true, $inline = false) {
+    public function getBarcodeSVG($code, $type, $w = 2, $h = 30, $color = 'black', $showCode = true, $inline = false) {
         if (!$this->store_path) {
             $this->setStorPath(app('config')->get("barcode.store_path"));
         }
@@ -131,7 +131,7 @@ class DNS1D {
      * @return string HTML code.
      * @protected
      */
-    protected function getBarcodeHTML($code, $type, $w = 2, $h = 30, $color = 'black', $showCode =false) {
+    public function getBarcodeHTML($code, $type, $w = 2, $h = 30, $color = 'black', $showCode =false) {
         if (!$this->store_path) {
             $this->setStorPath(app('config')->get("barcode.store_path"));
         }
@@ -169,7 +169,7 @@ class DNS1D {
      * @return image or false in case of error.
      * @protected
      */
-    protected function getBarcodePNG($code, $type, $w = 2, $h = 30, $color = array(0, 0, 0), $showCode = false) {
+    public function getBarcodePNG($code, $type, $w = 2, $h = 30, $color = array(0, 0, 0), $showCode = false) {
         if (!$this->store_path) {
             $this->setStorPath(app('config')->get("barcode.store_path"));
         }
@@ -245,7 +245,7 @@ class DNS1D {
      *
      * @return array
     */
-    protected function getBarcodeArray()
+    public function getBarcodeArray()
     {
         return $this->barcode_array;
     }

--- a/src/Milon/Barcode/DNS2D.php
+++ b/src/Milon/Barcode/DNS2D.php
@@ -92,7 +92,7 @@ class DNS2D {
      * @return string SVG code.
      * @protected
      */
-    protected function getBarcodeSVG($code, $type, $w = 3, $h = 3, $color = 'black') {
+    public function getBarcodeSVG($code, $type, $w = 3, $h = 3, $color = 'black') {
         if (!$this->store_path) {
             $this->setStorPath(app('config')->get("barcode.store_path"));
         }
@@ -138,7 +138,7 @@ class DNS2D {
      * @return string HTML code.
      * @protected
      */
-    protected function getBarcodeHTML($code, $type, $w = 10, $h = 10, $color = 'black') {
+    public function getBarcodeHTML($code, $type, $w = 10, $h = 10, $color = 'black') {
         if (!$this->store_path) {
             $this->setStorPath(app('config')->get("barcode.store_path"));
         }
@@ -178,7 +178,7 @@ class DNS2D {
      * @return path or false in case of error.
      * @protected
      */
-    protected function getBarcodePNG($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {
+    public function getBarcodePNG($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {
         if (!$this->store_path) {
             $this->setStorPath(app('config')->get("barcode.store_path"));
         }

--- a/src/Milon/Barcode/QRcode.php
+++ b/src/Milon/Barcode/QRcode.php
@@ -750,7 +750,7 @@ class QRcode {
      * @param $at (array) x,y position
      * @return value at specified position
      */
-    protected function getFrameAt($at) {
+    public function getFrameAt($at) {
         return ord($this->frame[$at['y']][$at['x']]);
     }
 
@@ -758,7 +758,7 @@ class QRcode {
      * Return the next frame position
      * @return array of x,y coordinates
      */
-    protected function getNextPosition() {
+    public function getNextPosition() {
         do {
             if ($this->bit == -1) {
                 $this->bit = 0;
@@ -864,7 +864,7 @@ class QRcode {
      * Return Reed-Solomon block code.
      * @return array rsblocks
      */
-    protected function getCode() {
+    public function getCode() {
         if ($this->count < $this->dataLength) {
             $row = $this->count % $this->blocks;
             $col = $this->count / $this->blocks;
@@ -2056,7 +2056,7 @@ class QRcode {
      * @param $items (int)
      * @return array padded merged byte stream
      */
-    protected function getBitStream($items) {
+    public function getBitStream($items) {
         $bstream = $this->mergeBitStream($items);
         return $this->appendPaddingBit($bstream);
     }
@@ -2066,7 +2066,7 @@ class QRcode {
      * @param $items (int)
      * @return array padded merged byte stream
      */
-    protected function getByteStream($items) {
+    public function getByteStream($items) {
         $bstream = $this->getBitStream($items);
         return $this->bitstreamToByte($bstream);
     }
@@ -2233,7 +2233,7 @@ class QRcode {
      * @param $level (int) error correction level
      * @return int maximum size (bytes)
      */
-    protected function getDataLength($version, $level) {
+    public function getDataLength($version, $level) {
         return $this->capacity[$version][QRCAP_WORDS] - $this->capacity[$version][QRCAP_EC][$level];
     }
 
@@ -2243,7 +2243,7 @@ class QRcode {
      * @param $level (int) error correction level
      * @return int ECC size (bytes)
      */
-    protected function getECCLength($version, $level) {
+    public function getECCLength($version, $level) {
         return $this->capacity[$version][QRCAP_EC][$level];
     }
 
@@ -2252,7 +2252,7 @@ class QRcode {
      * @param $version (int) version
      * @return int width
      */
-    protected function getWidth($version) {
+    public function getWidth($version) {
         return $this->capacity[$version][QRCAP_WIDTH];
     }
 
@@ -2261,7 +2261,7 @@ class QRcode {
      * @param $version (int) version
      * @return int number of remainder bits
      */
-    protected function getRemainder($version) {
+    public function getRemainder($version) {
         return $this->capacity[$version][QRCAP_REMINDER];
     }
 
@@ -2271,7 +2271,7 @@ class QRcode {
      * @param $level (int) error correction level
      * @return int version number
      */
-    protected function getMinimumVersion($size, $level) {
+    public function getMinimumVersion($size, $level) {
         for ($i = 1; $i <= QRSPEC_VERSION_MAX; ++$i) {
             $words = $this->capacity[$i][QRCAP_WORDS] - $this->capacity[$i][QRCAP_EC][$level];
             if ($words >= $size) {
@@ -2333,7 +2333,7 @@ class QRcode {
      * @param $spec (array) an array of ECC specification contains as following: {# of type1 blocks, # of data code, # of ecc code, # of type2 blocks, # of data code}
      * @return array spec
      */
-    protected function getEccSpec($version, $level, $spec) {
+    public function getEccSpec($version, $level, $spec) {
         if (count($spec) < 5) {
             $spec = array(0, 0, 0, 0, 0);
         }
@@ -2427,7 +2427,7 @@ class QRcode {
      * @param $version (int) version
      * @return BCH encoded version information pattern
      */
-    protected function getVersionPattern($version) {
+    public function getVersionPattern($version) {
         if (($version < 7) OR ($version > QRSPEC_VERSION_MAX)) {
             return 0;
         }
@@ -2440,7 +2440,7 @@ class QRcode {
      * @param $level (int) error correction level
      * @return BCH encoded format information pattern
      */
-    protected function getFormatInfo($mask, $level) {
+    public function getFormatInfo($mask, $level) {
         if (($mask < 0) OR ($mask > 7)) {
             return 0;
         }


### PR DESCRIPTION
I did those changes to avoid the following error at the static code analyser that we use here at my workplace (PHPStan):
$ php artisan code:analyse --env=testing
Configuration cache cleared!
 78/78 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------------------------------- 
  Line   app/Http/Controllers/EventsController.php                                      
 ------ ------------------------------------------------------------------------------- 
  107    Call to protected static method getBarcodeSVG() of class Milon\Barcode\DNS1D.  
 ------ ------------------------------------------------------------------------------- 

                                                                                                                  
 [ERROR] Found 1 error