### PR TITLE
Replace deprecated string offset access syntax

### DIFF
--- a/src/Milon/Barcode/DNS1D.php
+++ b/src/Milon/Barcode/DNS1D.php
@@ -557,7 +557,7 @@ class DNS1D {
         $k = 0;
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $char = $code{$i};
+            $char = $code[$i];
             if (!isset($chr[$char])) {
                 // invalid character
                 return false;
@@ -568,7 +568,7 @@ class DNS1D {
                 } else {
                     $t = false; // space
                 }
-                $w = $chr[$char]{$j};
+                $w = $chr[$char][$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -624,10 +624,10 @@ class DNS1D {
         $code_ext = '';
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            if (ord($code{$i}) > 127) {
+            if (ord($code[$i]) > 127) {
                 return false;
             }
-            $code_ext .= $encode[$code{$i}];
+            $code_ext .= $encode[$code[$i]];
         }
         return $code_ext;
     }
@@ -647,7 +647,7 @@ class DNS1D {
         $sum = 0;
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $k = array_keys($chars, $code{$i});
+            $k = array_keys($chars, $code[$i]);
             $sum += $k[0];
         }
         $j = ($sum % 43);
@@ -747,10 +747,10 @@ class DNS1D {
         $code_ext = '';
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            if (ord($code{$i}) > 127) {
+            if (ord($code[$i]) > 127) {
                 return false;
             }
-            $code_ext .= $encode[$code{$i}];
+            $code_ext .= $encode[$code[$i]];
         }
         // checksum
         $code_ext .= $this->checksum_code93($code_ext);
@@ -760,7 +760,7 @@ class DNS1D {
         $k = 0;
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $char = ord($code{$i});
+            $char = ord($code[$i]);
             if (!isset($chr[$char])) {
                 // invalid character
                 return false;
@@ -771,7 +771,7 @@ class DNS1D {
                 } else {
                     $t = false; // space
                 }
-                $w = $chr[$char]{$j};
+                $w = $chr[$char][$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -803,7 +803,7 @@ class DNS1D {
         $p = 1;
         $check = 0;
         for ($i = ($len - 1); $i >= 0; --$i) {
-            $k = array_keys($chars, $code{$i});
+            $k = array_keys($chars, $code[$i]);
             $check += ($k[0] * $p);
             ++$p;
             if ($p > 20) {
@@ -817,7 +817,7 @@ class DNS1D {
         $p = 1;
         $check = 0;
         for ($i = $len; $i >= 0; --$i) {
-            $k = array_keys($chars, $code{$i});
+            $k = array_keys($chars, $code[$i]);
             $check += ($k[0] * $p);
             ++$p;
             if ($p > 15) {
@@ -842,11 +842,11 @@ class DNS1D {
         $len = strlen($code);
         $sum = 0;
         for ($i = 0; $i < $len; $i+=2) {
-            $sum += $code{$i};
+            $sum += $code[$i];
         }
         $sum *= 3;
         for ($i = 1; $i < $len; $i+=2) {
-            $sum += ($code{$i});
+            $sum += ($code[$i]);
         }
         $r = $sum % 10;
         if ($r > 0) {
@@ -887,7 +887,7 @@ class DNS1D {
             $p = 2;
             $check = 0;
             for ($i = ($clen - 1); $i >= 0; --$i) {
-                $check += (hexdec($code{$i}) * $p);
+                $check += (hexdec($code[$i]) * $p);
                 ++$p;
                 if ($p > 7) {
                     $p = 2;
@@ -902,7 +902,7 @@ class DNS1D {
         $seq = '110'; // left guard
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $digit = $code{$i};
+            $digit = $code[$i];
             if (!isset($chr[$digit])) {
                 // invalid character
                 return false;
@@ -945,7 +945,7 @@ class DNS1D {
         $seq = '11011010';
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $digit = $code{$i};
+            $digit = $code[$i];
             if (!isset($chr[$digit])) {
                 // invalid character
                 return false;
@@ -971,8 +971,8 @@ class DNS1D {
         $k = 0;
         for ($i = 0; $i < $len; ++$i) {
             $w += 1;
-            if (($i == ($len - 1)) OR (($i < ($len - 1)) AND ($seq{$i} != $seq{($i + 1)}))) {
-                if ($seq{$i} == '1') {
+            if (($i == ($len - 1)) OR (($i < ($len - 1)) AND ($seq[$i] != $seq[($i + 1)]))) {
+                if ($seq[$i] == '1') {
                     $t = true; // bar
                 } else {
                     $t = false; // space
@@ -1023,8 +1023,8 @@ class DNS1D {
         $k = 0;
         $clen = strlen($code);
         for ($i = 0; $i < $clen; $i = ($i + 2)) {
-            $char_bar = $code{$i};
-            $char_space = $code{$i + 1};
+            $char_bar = $code[$i];
+            $char_space = $code[$i + 1];
             if ((!isset($chr[$char_bar])) OR (!isset($chr[$char_space]))) {
                 // invalid character
                 return false;
@@ -1033,7 +1033,7 @@ class DNS1D {
             $seq = '';
             $chrlen = strlen($chr[$char_bar]);
             for ($s = 0; $s < $chrlen; $s++) {
-                $seq .= $chr[$char_bar]{$s} . $chr[$char_space]{$s};
+                $seq .= $chr[$char_bar][$s] . $chr[$char_space][$s];
             }
             $seqlen = strlen($seq);
             for ($j = 0; $j < $seqlen; ++$j) {
@@ -1042,7 +1042,7 @@ class DNS1D {
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -1189,7 +1189,7 @@ class DNS1D {
             case 'A': { // MODE A
                     $startid = 103;
                     for ($i = 0; $i < $len; ++$i) {
-                        $char = $code{$i};
+                        $char = $code[$i];
                         $char_id = ord($char);
                         if (($char_id >= 241) AND ($char_id <= 244)) {
                             $code_data[] = $fnc_a[$char_id];
@@ -1204,7 +1204,7 @@ class DNS1D {
             case 'B': { // MODE B
                     $startid = 104;
                     for ($i = 0; $i < $len; ++$i) {
-                        $char = $code{$i};
+                        $char = $code[$i];
                         $char_id = ord($char);
                         if (($char_id >= 241) AND ($char_id <= 244)) {
                             $code_data[] = $fnc_b[$char_id];
@@ -1218,7 +1218,7 @@ class DNS1D {
                 }
             case 'C': { // MODE C
                     $startid = 105;
-                    if (ord($code{0}) == 241) {
+                    if (ord($code[0]) == 241) {
                         $code_data[] = 102;
                         $code = substr($code, 1);
                         --$len;
@@ -1228,7 +1228,7 @@ class DNS1D {
                         return false;
                     }
                     for ($i = 0; $i < $len; $i+=2) {
-                        $chrnum = $code{$i} . $code{$i + 1};
+                        $chrnum = $code[$i] . $code[$i + 1];
                         if (preg_match('/([0-9]{2})/', $chrnum) > 0) {
                             $code_data[] = intval($chrnum);
                         } else {
@@ -1284,7 +1284,7 @@ class DNS1D {
                                         }
                                     }
                                     for ($i = 0; $i < $seq[2]; ++$i) {
-                                        $char = $seq[1]{$i};
+                                        $char = $seq[1][$i];
                                         $char_id = ord($char);
                                         if (($char_id >= 241) AND ($char_id <= 244)) {
                                             $code_data[] = $fnc_a[$char_id];
@@ -1296,7 +1296,7 @@ class DNS1D {
                                 }
                             case 'B': {
                                     if ($key == 0) {
-                                        $tmpchr = ord($seq[1]{0});
+                                        $tmpchr = ord($seq[1][0]);
                                         if (($seq[2] == 1) AND ($tmpchr >= 241) AND ($tmpchr <= 244) AND isset($sequence[($key + 1)]) AND ($sequence[($key + 1)][0] != 'B')) {
                                             switch ($sequence[($key + 1)][0]) {
                                                 case 'A': {
@@ -1327,7 +1327,7 @@ class DNS1D {
                                         }
                                     }
                                     for ($i = 0; $i < $seq[2]; ++$i) {
-                                        $char = $seq[1]{$i};
+                                        $char = $seq[1][$i];
                                         $char_id = ord($char);
                                         if (($char_id >= 241) AND ($char_id <= 244)) {
                                             $code_data[] = $fnc_b[$char_id];
@@ -1344,7 +1344,7 @@ class DNS1D {
                                         $code_data[] = 99;
                                     }
                                     for ($i = 0; $i < $seq[2]; $i+=2) {
-                                        $chrnum = $seq[1]{$i} . $seq[1]{$i + 1};
+                                        $chrnum = $seq[1][$i] . $seq[1][$i + 1];
                                         $code_data[] = intval($chrnum);
                                     }
                                     break;
@@ -1375,7 +1375,7 @@ class DNS1D {
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$j];
                 $bararray['bcode'][] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
             }
@@ -1449,14 +1449,14 @@ class DNS1D {
         // calculate check digit
         $sum_a = 0;
         for ($i = 1; $i < $data_len; $i+=2) {
-            $sum_a += $code{$i};
+            $sum_a += $code[$i];
         }
         if ($len > 12) {
             $sum_a *= 3;
         }
         $sum_b = 0;
         for ($i = 0; $i < $data_len; $i+=2) {
-            $sum_b += ($code{$i});
+            $sum_b += ($code[$i]);
         }
         if ($len < 13) {
             $sum_b *= 3;
@@ -1468,8 +1468,8 @@ class DNS1D {
         if ($code_len == $data_len) {
             // add check digit
             $code .= $r;
-        } elseif ($r !== intval($code{$data_len})) {
-			throw new \Milon\Barcode\WrongCheckDigitException($r, intval($code{$data_len}));
+        } elseif ($r !== intval($code[$data_len])) {
+			throw new \Milon\Barcode\WrongCheckDigitException($r, intval($code[$data_len]));
         }
         if ($len == 12) {
             // UPC-A
@@ -1576,9 +1576,9 @@ class DNS1D {
         $seq = '101'; // left guard bar
         if ($upce) {
             $bararray = array('code' => $upce_code, 'maxw' => 0, 'maxh' => 1, 'bcode' => array());
-            $p = $upce_parities[$code{1}][$r];
+            $p = $upce_parities[$code[1]][$r];
             for ($i = 0; $i < 6; ++$i) {
-                $seq .= $codes[$p[$i]][$upce_code{$i}];
+                $seq .= $codes[$p[$i]][$upce_code[$i]];
             }
             $seq .= '010101'; // right guard bar
         } else {
@@ -1586,17 +1586,17 @@ class DNS1D {
             $half_len = ceil($len / 2);
             if ($len == 8) {
                 for ($i = 0; $i < $half_len; ++$i) {
-                    $seq .= $codes['A'][$code{$i}];
+                    $seq .= $codes['A'][$code[$i]];
                 }
             } else {
-                $p = $parities[$code{0}];
+                $p = $parities[$code[0]];
                 for ($i = 1; $i < $half_len; ++$i) {
-                    $seq .= $codes[$p[$i - 1]][$code{$i}];
+                    $seq .= $codes[$p[$i - 1]][$code[$i]];
                 }
             }
             $seq .= '01010'; // center guard bar
             for ($i = $half_len; $i < $len; ++$i) {
-                $seq .= $codes['C'][$code{intval($i)}];
+                $seq .= $codes['C'][$code[intval($i)]];
             }
             $seq .= '101'; // right guard bar
         }
@@ -1604,8 +1604,8 @@ class DNS1D {
         $w = 0;
         for ($i = 0; $i < $clen; ++$i) {
             $w += 1;
-            if (($i == ($clen - 1)) OR (($i < ($clen - 1)) AND ($seq{$i} != $seq{($i + 1)}))) {
-                if ($seq{$i} == '1') {
+            if (($i == ($clen - 1)) OR (($i < ($clen - 1)) AND ($seq[$i] != $seq[($i + 1)]))) {
+                if ($seq[$i] == '1') {
                     $t = true; // bar
                 } else {
                     $t = false; // space
@@ -1635,7 +1635,7 @@ class DNS1D {
         if ($len == 2) {
             $r = $code % 4;
         } elseif ($len == 5) {
-            $r = (3 * ($code{0} + $code{2} + $code{4})) + (9 * ($code{1} + $code{3}));
+            $r = (3 * ($code[0] + $code[2] + $code[4])) + (9 * ($code[1] + $code[3]));
             $r %= 10;
         } else {
             return false;
@@ -1686,10 +1686,10 @@ class DNS1D {
         );
         $p = $parities[$len][$r];
         $seq = '1011'; // left guard bar
-        $seq .= $codes[$p[0]][$code{0}];
+        $seq .= $codes[$p[0]][$code[0]];
         for ($i = 1; $i < $len; ++$i) {
             $seq .= '01'; // separator
-            $seq .= $codes[$p[$i]][$code{$i}];
+            $seq .= $codes[$p[$i]][$code[$i]];
         }
         $bararray = array('code' => $code, 'maxw' => 0, 'maxh' => 1, 'bcode' => array());
         return $this->binseq_to_array($seq, $bararray);
@@ -1740,7 +1740,7 @@ class DNS1D {
         // calculate checksum
         $sum = 0;
         for ($i = 0; $i < $len; ++$i) {
-            $sum += intval($code{$i});
+            $sum += intval($code[$i]);
         }
         $chkd = ($sum % 10);
         if ($chkd > 0) {
@@ -1754,7 +1754,7 @@ class DNS1D {
         $bararray['maxw'] += 2;
         for ($i = 0; $i < $len; ++$i) {
             for ($j = 0; $j < 5; ++$j) {
-                $h = $barlen[$code{$i}][$j];
+                $h = $barlen[$code[$i]][$j];
                 $p = floor(1 / $h);
                 $bararray['bcode'][$k++] = array('t' => 1, 'w' => 1, 'h' => $h, 'p' => $p);
                 $bararray['bcode'][$k++] = array('t' => 0, 'w' => 1, 'h' => 2, 'p' => 0);
@@ -1867,8 +1867,8 @@ class DNS1D {
             $row = 0;
             $col = 0;
             for ($i = 0; $i < $len; ++$i) {
-                $row += $checktable[$code{$i}][0];
-                $col += $checktable[$code{$i}][1];
+                $row += $checktable[$code[$i]][0];
+                $col += $checktable[$code[$i]][1];
             }
             $row %= 6;
             $col %= 6;
@@ -1885,7 +1885,7 @@ class DNS1D {
         }
         for ($i = 0; $i < $len; ++$i) {
             for ($j = 0; $j < 4; ++$j) {
-                switch ($barmode[$code{$i}][$j]) {
+                switch ($barmode[$code[$i]][$j]) {
                     case 1: {
                             $p = 0;
                             $h = 2;
@@ -1957,17 +1957,17 @@ class DNS1D {
         $code = 'A' . strtoupper($code) . 'A';
         $len = strlen($code);
         for ($i = 0; $i < $len; ++$i) {
-            if (!isset($chr[$code{$i}])) {
+            if (!isset($chr[$code[$i]])) {
                 return false;
             }
-            $seq = $chr[$code{$i}];
+            $seq = $chr[$code[$i]];
             for ($j = 0; $j < 8; ++$j) {
                 if (($j % 2) == 0) {
                     $t = true; // bar
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -2007,7 +2007,7 @@ class DNS1D {
         $p = 1;
         $check = 0;
         for ($i = ($len - 1); $i >= 0; --$i) {
-            $digit = $code{$i};
+            $digit = $code[$i];
             if ($digit == '-') {
                 $dval = 10;
             } else {
@@ -2029,7 +2029,7 @@ class DNS1D {
             $p = 1;
             $check = 0;
             for ($i = $len; $i >= 0; --$i) {
-                $digit = $code{$i};
+                $digit = $code[$i];
                 if ($digit == '-') {
                     $dval = 10;
                 } else {
@@ -2048,17 +2048,17 @@ class DNS1D {
         $code = 'S' . $code . 'S';
         $len += 3;
         for ($i = 0; $i < $len; ++$i) {
-            if (!isset($chr[$code{$i}])) {
+            if (!isset($chr[$code[$i]])) {
                 return false;
             }
-            $seq = $chr[$code{$i}];
+            $seq = $chr[$code[$i]];
             for ($j = 0; $j < 6; ++$j) {
                 if (($j % 2) == 0) {
                     $t = true; // bar
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -2127,7 +2127,7 @@ class DNS1D {
         $bararray = array('code' => $code, 'maxw' => 0, 'maxh' => 2, 'bcode' => array());
         $len = strlen($seq);
         for ($i = 0; $i < $len; ++$i) {
-            switch ($seq{$i}) {
+            switch ($seq[$i]) {
                 case '1': {
                         $p = 1;
                         $h = 1;
@@ -2198,9 +2198,9 @@ class DNS1D {
                 }
         }
         $binary_code = bcmul($binary_code, 10);
-        $binary_code = bcadd($binary_code, $tracking_number{0});
+        $binary_code = bcadd($binary_code, $tracking_number[0]);
         $binary_code = bcmul($binary_code, 5);
-        $binary_code = bcadd($binary_code, $tracking_number{1});
+        $binary_code = bcadd($binary_code, $tracking_number[1]);
         $binary_code .= substr($tracking_number, 2, 18);
         // convert to hexadecimal
         $binary_code = $this->dec_to_hex($binary_code);
@@ -2315,7 +2315,7 @@ class DNS1D {
         $bitval = 1;
         $len = strlen($hex);
         for ($pos = ($len - 1); $pos >= 0; --$pos) {
-            $dec = bcadd($dec, bcmul(hexdec($hex{$pos}), $bitval));
+            $dec = bcadd($dec, bcmul(hexdec($hex[$pos]), $bitval));
             $bitval = bcmul($bitval, 16);
         }
         return $dec;

--- a/src/Milon/Barcode/Datamatrix.php
+++ b/src/Milon/Barcode/Datamatrix.php
@@ -543,7 +543,7 @@ class Datamatrix {
                 return ENC_C40;
             }
             // get char
-            $chr = ord($data{($pos + $charscount)});
+            $chr = ord($data[($pos + $charscount)]);
             $charscount++;
             // STEP L
             if ($this->isCharMode($chr, ENC_ASCII_NUM)) {
@@ -618,7 +618,7 @@ class Datamatrix {
                     if ($numch[ENC_C40] == $numch[ENC_X12]) {
                         $k = ($pos + $charscount + 1);
                         while ($k < $data_length) {
-                            $tmpchr = ord($data{$k});
+                            $tmpchr = ord($data[$k]);
                             if ($this->isCharMode($tmpchr, ENC_X12)) {
                                 return ENC_X12;
                             } elseif (!($this->isCharMode($tmpchr, ENC_X12) OR $this->isCharMode($tmpchr, ENC_C40))) {
@@ -700,7 +700,7 @@ class Datamatrix {
         while ($pos < $data_lenght) {
             switch ($enc) {
                 case ENC_ASCII: { // STEP B. While in ASCII encodation
-                        if (($data_lenght > 1) AND ($pos < ($data_lenght - 1)) AND ($this->isCharMode(ord($data{($pos)}), ENC_ASCII_NUM) AND $this->isCharMode(ord($data{($pos + 1)}), ENC_ASCII_NUM))) {
+                        if (($data_lenght > 1) AND ($pos < ($data_lenght - 1)) AND ($this->isCharMode(ord($data[($pos)]), ENC_ASCII_NUM) AND $this->isCharMode(ord($data[($pos + 1)]), ENC_ASCII_NUM))) {
                             // 1. If the next data sequence is at least 2 consecutive digits, encode the next two digits as a double digit in ASCII mode.
                             $cw[] = (intval(substr($data, $pos, 2)) + 130);
                             ++$cw_num;
@@ -715,7 +715,7 @@ class Datamatrix {
                                 ++$cw_num;
                             } else {
                                 // get new byte
-                                $chr = ord($data{($pos)});
+                                $chr = ord($data[($pos)]);
                                 ++$pos;
                                 if ($this->isCharMode($chr, ENC_ASCII_EXT)) {
                                     // 3. If the next data character is extended ASCII (greater than 127) encode it in ASCII mode first using the Upper Shift (value 235) character.
@@ -743,7 +743,7 @@ class Datamatrix {
                         $charset = $this->chset[$set_id];
                         do {
                             // 2. process the next character in C40 encodation.
-                            $chr = ord($data{($epos)});
+                            $chr = ord($data[($epos)]);
                             ++$epos;
                             // check for extended character
                             if ($chr & 0x80) {
@@ -839,7 +839,7 @@ class Datamatrix {
                         $field_lenght = 0;
                         while ($epos < $data_lenght) {
                             // 2. process the next character in EDIFACT encodation.
-                            $chr = ord($data{($epos)});
+                            $chr = ord($data[($epos)]);
                             ++$epos;
                             $temp_cw[] = $chr;
                             ++$field_lenght;
@@ -899,7 +899,7 @@ class Datamatrix {
                                 break; // exit from B256 mode
                             } else {
                                 // 2. Otherwise, process the next character in Base 256 encodation.
-                                $chr = ord($data{($pos)});
+                                $chr = ord($data[($pos)]);
                                 ++$pos;
                                 $temp_cw[] = $chr;
                                 ++$field_lenght;

--- a/src/Milon/Barcode/PDF417.php
+++ b/src/Milon/Barcode/PDF417.php
@@ -877,7 +877,7 @@ class PDF417 {
                     $txtarr = array(); // array of characters and sub-mode switching characters
                     $codelen = strlen($code);
                     for ($i = 0; $i < $codelen; ++$i) {
-                        $chval = ord($code{$i});
+                        $chval = ord($code[$i]);
                         if (($k = array_search($chval, $this->textsubmodes[$submode])) !== false) {
                             // we are on the same sub-mode
                             $txtarr[] = $k;
@@ -887,7 +887,7 @@ class PDF417 {
                                 // search new sub-mode
                                 if (($s != $submode) AND (($k = array_search($chval, $this->textsubmodes[$s])) !== false)) {
                                     // $s is the new submode
-                                    if (((($i + 1) == $codelen) OR ((($i + 1) < $codelen) AND (array_search(ord($code{($i + 1)}), $this->textsubmodes[$submode]) !== false))) AND (($s == 3) OR (($s == 0) AND ($submode == 1)))) {
+                                    if (((($i + 1) == $codelen) OR ((($i + 1) < $codelen) AND (array_search(ord($code[($i + 1)]), $this->textsubmodes[$submode]) !== false))) AND (($s == 3) OR (($s == 0) AND ($submode == 1)))) {
                                         // shift (temporary change only for this char)
                                         if ($s == 3) {
                                             // shift to puntuaction
@@ -933,12 +933,12 @@ class PDF417 {
                             $sublen = strlen($code);
                         }
                         if ($sublen == 6) {
-                            $t = bcmul('' . ord($code{0}), '1099511627776');
-                            $t = bcadd($t, bcmul('' . ord($code{1}), '4294967296'));
-                            $t = bcadd($t, bcmul('' . ord($code{2}), '16777216'));
-                            $t = bcadd($t, bcmul('' . ord($code{3}), '65536'));
-                            $t = bcadd($t, bcmul('' . ord($code{4}), '256'));
-                            $t = bcadd($t, '' . ord($code{5}));
+                            $t = bcmul('' . ord($code[0]), '1099511627776');
+                            $t = bcadd($t, bcmul('' . ord($code[1]), '4294967296'));
+                            $t = bcadd($t, bcmul('' . ord($code[2]), '16777216'));
+                            $t = bcadd($t, bcmul('' . ord($code[3]), '65536'));
+                            $t = bcadd($t, bcmul('' . ord($code[4]), '256'));
+                            $t = bcadd($t, '' . ord($code[5]));
                             do {
                                 $d = bcmod($t, '900');
                                 $t = bcdiv($t, '900');
@@ -946,7 +946,7 @@ class PDF417 {
                             } while ($t != '0');
                         } else {
                             for ($i = 0; $i < $sublen; ++$i) {
-                                $cw[] = ord($code{$i});
+                                $cw[] = ord($code[$i]);
                             }
                         }
                         $code = $rest;


### PR DESCRIPTION
This PR replaces the deprecated curly brace syntax for array and string access. 

Ref.: https://wiki.php.net/rfc/deprecate_curly_braces_array_access
