### PR TITLE
Always end store path with slash

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,13 +20,13 @@ This package relies on [php-gd](http://php.net/manual/en/book.image.php) extensi
 
 Begin by installing this package through Composer. Just run following command to terminal-
 
-```
+```shell script
 composer require milon/barcode
 ```
 
 You can also edit your project's `composer.json` file to require `milon/barcode`.
 
-```
+```json
 "require": {
     ...
     "milon/barcode": "^7.0"
@@ -35,7 +35,7 @@ You can also edit your project's `composer.json` file to require `milon/barcode`
 
 For Laravel 6.* use this-
 
-```
+```json
 "require": {
     ...
     "milon/barcode": "^6.0"
@@ -44,7 +44,7 @@ For Laravel 6.* use this-
 
 For Laravel 5.0 and 5.1 use this-
 
-```
+```json
 "require": {
     ...
     "milon/barcode": "^5.1"
@@ -53,7 +53,7 @@ For Laravel 5.0 and 5.1 use this-
 
 For Laravel 4.0, 4.1 and 4.2 use this-
 
-```
+```json
 "require": {
     ...
     "milon/barcode": "^4.2"
@@ -62,7 +62,7 @@ For Laravel 4.0, 4.1 and 4.2 use this-
 
 Next, update Composer from the Terminal:
 
-```
+```shell script
 composer update
 ```
 
@@ -70,9 +70,8 @@ Once this operation completes, the final step is to add the service provider. Op
 
 ```php
 'providers' => [
-    ...
+    // ...
     Milon\Barcode\BarcodeServiceProvider::class,
-    ...
 ]
 ```
 
@@ -80,14 +79,14 @@ For version 4.* add these lines on `app/config/app.php` file-
 
 ```php
 'providers' => array(
-    ...
+    // ...
     'Milon\Barcode\BarcodeServiceProvider',
 )
 ```
 
 If you want to change Bar-code's settings (Store Path etc.), you need to publish its config file(s). For that you need to run in the terminal-
 
-```
+```shell script
 # Laravel 5.x
 php artisan vendor:publish
 
@@ -101,7 +100,7 @@ Now add the alias.
 
 ```php
 'aliases' => [
-    ...
+    // ...
     'DNS1D' => Milon\Barcode\Facades\DNS1DFacade::class,
     'DNS2D' => Milon\Barcode\Facades\DNS2DFacade::class,
 ]
@@ -111,7 +110,7 @@ For version 4.2 alias will be like this-
 
 ```php
 'aliases' => array(
-    ...
+    // ...
     'DNS1D' => 'Milon\Barcode\Facades\DNS1DFacade',
     'DNS2D' => 'Milon\Barcode\Facades\DNS2DFacade',
 )
@@ -122,92 +121,92 @@ Bar-code generator like Qr Code, PDF417, C39,C39+, C39E,C39E+, C93, S25,S25+, I2
 generator in html, png embedded base64 code and SVG canvas
 
 ```php
-echo DNS1D::getBarcodeSVG("4445645656", "PHARMA2T");
-echo DNS1D::getBarcodeHTML("4445645656", "PHARMA2T");
-echo '<img src="data:image/png,' . DNS1D::getBarcodePNG("4", "C39+") . '" alt="barcode"   />';
-echo DNS1D::getBarcodePNGPath("4445645656", "PHARMA2T");
-echo '<img src="data:image/png;base64,' . DNS1D::getBarcodePNG("4", "C39+") . '" alt="barcode"   />';
+echo DNS1D::getBarcodeSVG('4445645656', 'PHARMA2T');
+echo DNS1D::getBarcodeHTML('4445645656', 'PHARMA2T');
+echo '<img src="data:image/png,' . DNS1D::getBarcodePNG('4', 'C39+') . '" alt="barcode"   />';
+echo DNS1D::getBarcodePNGPath('4445645656', 'PHARMA2T');
+echo '<img src="data:image/png;base64,' . DNS1D::getBarcodePNG('4', 'C39+') . '" alt="barcode"   />';
 ```
 
 ```php
-echo DNS1D::getBarcodeSVG("4445645656", "C39");
-echo DNS2D::getBarcodeHTML("4445645656", "QRCODE");
-echo DNS2D::getBarcodePNGPath("4445645656", "PDF417");
-echo DNS2D::getBarcodeSVG("4445645656", "DATAMATRIX");
-echo '<img src="data:image/png;base64,' . DNS2D::getBarcodePNG("4", "PDF417") . '" alt="barcode"   />';
+echo DNS1D::getBarcodeSVG('4445645656', 'C39');
+echo DNS2D::getBarcodeHTML('4445645656', 'QRCODE');
+echo DNS2D::getBarcodePNGPath('4445645656', 'PDF417');
+echo DNS2D::getBarcodeSVG('4445645656', 'DATAMATRIX');
+echo '<img src="data:image/png;base64,' . DNS2D::getBarcodePNG('4', 'PDF417') . '" alt="barcode"   />';
 ```
 
 ## Width and Height example
 
 ```php
-echo DNS1D::getBarcodeSVG("4445645656", "PHARMA2T",3,33);
-echo DNS1D::getBarcodeHTML("4445645656", "PHARMA2T",3,33);
-echo '<img src="' . DNS1D::getBarcodePNG("4", "C39+",3,33) . '" alt="barcode"   />';
-echo DNS1D::getBarcodePNGPath("4445645656", "PHARMA2T",3,33);
-echo '<img src="data:image/png;base64,' . DNS1D::getBarcodePNG("4", "C39+",3,33) . '" alt="barcode"   />';
+echo DNS1D::getBarcodeSVG('4445645656', 'PHARMA2T',3,33);
+echo DNS1D::getBarcodeHTML('4445645656', 'PHARMA2T',3,33);
+echo '<img src="' . DNS1D::getBarcodePNG('4', 'C39+',3,33) . '" alt="barcode"   />';
+echo DNS1D::getBarcodePNGPath('4445645656', 'PHARMA2T',3,33);
+echo '<img src="data:image/png;base64,' . DNS1D::getBarcodePNG('4', 'C39+',3,33) . '" alt="barcode"   />';
 ```
 
 ## Color
 
 ```php
-echo DNS1D::getBarcodeSVG("4445645656", "PHARMA2T",3,33,"green");
-echo DNS1D::getBarcodeHTML("4445645656", "PHARMA2T",3,33,"green");
-echo '<img src="' . DNS1D::getBarcodePNG("4", "C39+",3,33,array(1,1,1)) . '" alt="barcode"   />';
-echo DNS1D::getBarcodePNGPath("4445645656", "PHARMA2T",3,33,array(255,255,0));
-echo '<img src="data:image/png;base64,' . DNS1D::getBarcodePNG("4", "C39+",3,33,array(1,1,1)) . '" alt="barcode"   />';
+echo DNS1D::getBarcodeSVG('4445645656', 'PHARMA2T',3,33,'green');
+echo DNS1D::getBarcodeHTML('4445645656', 'PHARMA2T',3,33,'green');
+echo '<img src="' . DNS1D::getBarcodePNG('4', 'C39+',3,33,array(1,1,1)) . '" alt="barcode"   />';
+echo DNS1D::getBarcodePNGPath('4445645656', 'PHARMA2T',3,33,array(255,255,0));
+echo '<img src="data:image/png;base64,' . DNS1D::getBarcodePNG('4', 'C39+',3,33,array(1,1,1)) . '" alt="barcode"   />';
 ```
 
 ## Show Text
 
 ```php
-echo DNS1D::getBarcodeSVG("4445645656", "PHARMA2T",3,33,"green", true);
-echo DNS1D::getBarcodeHTML("4445645656", "PHARMA2T",3,33,"green", true);
-echo '<img src="' . DNS1D::getBarcodePNG("4", "C39+",3,33,array(1,1,1), true) . '" alt="barcode"   />';
-echo DNS1D::getBarcodePNGPath("4445645656", "PHARMA2T",3,33,array(255,255,0), true);
-echo '<img src="data:image/png;base64,' . DNS1D::getBarcodePNG("4", "C39+",3,33,array(1,1,1), true) . '" alt="barcode"   />';
+echo DNS1D::getBarcodeSVG('4445645656', 'PHARMA2T',3,33,'green', true);
+echo DNS1D::getBarcodeHTML('4445645656', 'PHARMA2T',3,33,'green', true);
+echo '<img src="' . DNS1D::getBarcodePNG('4', 'C39+',3,33,array(1,1,1), true) . '" alt="barcode"   />';
+echo DNS1D::getBarcodePNGPath('4445645656', 'PHARMA2T',3,33,array(255,255,0), true);
+echo '<img src="data:image/png;base64,' . DNS1D::getBarcodePNG('4', 'C39+',3,33,array(1,1,1), true) . '" alt="barcode"   />';
 ```
 
 ## 2D Barcodes
 
 ```php
-echo DNS2D::getBarcodeHTML("4445645656", "QRCODE");
-echo DNS2D::getBarcodePNGPath("4445645656", "PDF417");
-echo DNS2D::getBarcodeSVG("4445645656", "DATAMATRIX");
+echo DNS2D::getBarcodeHTML('4445645656', 'QRCODE');
+echo DNS2D::getBarcodePNGPath('4445645656', 'PDF417');
+echo DNS2D::getBarcodeSVG('4445645656', 'DATAMATRIX');
 ```
 
 ## 1D Barcodes
 
 ```php
-echo DNS1D::getBarcodeHTML("4445645656", "C39");
-echo DNS1D::getBarcodeHTML("4445645656", "C39+");
-echo DNS1D::getBarcodeHTML("4445645656", "C39E");
-echo DNS1D::getBarcodeHTML("4445645656", "C39E+");
-echo DNS1D::getBarcodeHTML("4445645656", "C93");
-echo DNS1D::getBarcodeHTML("4445645656", "S25");
-echo DNS1D::getBarcodeHTML("4445645656", "S25+");
-echo DNS1D::getBarcodeHTML("4445645656", "I25");
-echo DNS1D::getBarcodeHTML("4445645656", "I25+");
-echo DNS1D::getBarcodeHTML("4445645656", "C128");
-echo DNS1D::getBarcodeHTML("4445645656", "C128A");
-echo DNS1D::getBarcodeHTML("4445645656", "C128B");
-echo DNS1D::getBarcodeHTML("4445645656", "C128C");
-echo DNS1D::getBarcodeHTML("44455656", "EAN2");
-echo DNS1D::getBarcodeHTML("4445656", "EAN5");
-echo DNS1D::getBarcodeHTML("4445", "EAN8");
-echo DNS1D::getBarcodeHTML("4445", "EAN13");
-echo DNS1D::getBarcodeHTML("4445645656", "UPCA");
-echo DNS1D::getBarcodeHTML("4445645656", "UPCE");
-echo DNS1D::getBarcodeHTML("4445645656", "MSI");
-echo DNS1D::getBarcodeHTML("4445645656", "MSI+");
-echo DNS1D::getBarcodeHTML("4445645656", "POSTNET");
-echo DNS1D::getBarcodeHTML("4445645656", "PLANET");
-echo DNS1D::getBarcodeHTML("4445645656", "RMS4CC");
-echo DNS1D::getBarcodeHTML("4445645656", "KIX");
-echo DNS1D::getBarcodeHTML("4445645656", "IMB");
-echo DNS1D::getBarcodeHTML("4445645656", "CODABAR");
-echo DNS1D::getBarcodeHTML("4445645656", "CODE11");
-echo DNS1D::getBarcodeHTML("4445645656", "PHARMA");
-echo DNS1D::getBarcodeHTML("4445645656", "PHARMA2T");
+echo DNS1D::getBarcodeHTML('4445645656', 'C39');
+echo DNS1D::getBarcodeHTML('4445645656', 'C39+');
+echo DNS1D::getBarcodeHTML('4445645656', 'C39E');
+echo DNS1D::getBarcodeHTML('4445645656', 'C39E+');
+echo DNS1D::getBarcodeHTML('4445645656', 'C93');
+echo DNS1D::getBarcodeHTML('4445645656', 'S25');
+echo DNS1D::getBarcodeHTML('4445645656', 'S25+');
+echo DNS1D::getBarcodeHTML('4445645656', 'I25');
+echo DNS1D::getBarcodeHTML('4445645656', 'I25+');
+echo DNS1D::getBarcodeHTML('4445645656', 'C128');
+echo DNS1D::getBarcodeHTML('4445645656', 'C128A');
+echo DNS1D::getBarcodeHTML('4445645656', 'C128B');
+echo DNS1D::getBarcodeHTML('4445645656', 'C128C');
+echo DNS1D::getBarcodeHTML('44455656', 'EAN2');
+echo DNS1D::getBarcodeHTML('4445656', 'EAN5');
+echo DNS1D::getBarcodeHTML('4445', 'EAN8');
+echo DNS1D::getBarcodeHTML('4445', 'EAN13');
+echo DNS1D::getBarcodeHTML('4445645656', 'UPCA');
+echo DNS1D::getBarcodeHTML('4445645656', 'UPCE');
+echo DNS1D::getBarcodeHTML('4445645656', 'MSI');
+echo DNS1D::getBarcodeHTML('4445645656', 'MSI+');
+echo DNS1D::getBarcodeHTML('4445645656', 'POSTNET');
+echo DNS1D::getBarcodeHTML('4445645656', 'PLANET');
+echo DNS1D::getBarcodeHTML('4445645656', 'RMS4CC');
+echo DNS1D::getBarcodeHTML('4445645656', 'KIX');
+echo DNS1D::getBarcodeHTML('4445645656', 'IMB');
+echo DNS1D::getBarcodeHTML('4445645656', 'CODABAR');
+echo DNS1D::getBarcodeHTML('4445645656', 'CODE11');
+echo DNS1D::getBarcodeHTML('4445645656', 'PHARMA');
+echo DNS1D::getBarcodeHTML('4445645656', 'PHARMA2T');
 ```
 
 # Running without Laravel
@@ -216,12 +215,12 @@ You can use this library without using Laravel.
 
 Example:
 
-```
+```php
 use \Milon\Barcode\DNS1D;
 
 $d = new DNS1D();
-$d->setStorPath(__DIR__."/cache/");
-echo $d->getBarcodeHTML("9780691147727", "EAN13");
+$d->setStorPath(__DIR__.'/cache/');
+echo $d->getBarcodeHTML('9780691147727', 'EAN13');
 ```
 
 ## License

--- a/src/Milon/Barcode/DNS1D.php
+++ b/src/Milon/Barcode/DNS1D.php
@@ -2419,7 +2419,7 @@ class DNS1D {
     }
 
     protected function setStorPath($path) {
-        $this->store_path = $path;
+        $this->store_path = rtrim($path, '/' . DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         return $this;
     }
 

--- a/src/Milon/Barcode/DNS2D.php
+++ b/src/Milon/Barcode/DNS2D.php
@@ -406,7 +406,7 @@ class DNS2D {
     }
 
     protected function setStorPath($path) {
-        $this->store_path = $path;
+        $this->store_path = rtrim($path, '/' . DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         return $this;
     }
 


### PR DESCRIPTION
If the store path didn't end in a slash then the generated paths were incorrect. This PR ensures that the store path always ends with a slash.