### PR TITLE
[v6] Replace deprecated string offset access syntax

### DIFF
--- a/src/Milon/Barcode/Datamatrix.php
+++ b/src/Milon/Barcode/Datamatrix.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Milon\Barcode;
 
@@ -543,7 +543,7 @@ class Datamatrix {
                 return ENC_C40;
             }
             // get char
-            $chr = ord($data{($pos + $charscount)});
+            $chr = ord($data[($pos + $charscount)]);
             $charscount++;
             // STEP L
             if ($this->isCharMode($chr, ENC_ASCII_NUM)) {
@@ -618,7 +618,7 @@ class Datamatrix {
                     if ($numch[ENC_C40] == $numch[ENC_X12]) {
                         $k = ($pos + $charscount + 1);
                         while ($k < $data_length) {
-                            $tmpchr = ord($data{$k});
+                            $tmpchr = ord($data[$k]);
                             if ($this->isCharMode($tmpchr, ENC_X12)) {
                                 return ENC_X12;
                             } elseif (!($this->isCharMode($tmpchr, ENC_X12) OR $this->isCharMode($tmpchr, ENC_C40))) {
@@ -700,7 +700,7 @@ class Datamatrix {
         while ($pos < $data_lenght) {
             switch ($enc) {
                 case ENC_ASCII: { // STEP B. While in ASCII encodation
-                        if (($data_lenght > 1) AND ($pos < ($data_lenght - 1)) AND ($this->isCharMode(ord($data{($pos)}), ENC_ASCII_NUM) AND $this->isCharMode(ord($data{($pos + 1)}), ENC_ASCII_NUM))) {
+                        if (($data_lenght > 1) AND ($pos < ($data_lenght - 1)) AND ($this->isCharMode(ord($data[($pos)]), ENC_ASCII_NUM) AND $this->isCharMode(ord($data[($pos + 1)]), ENC_ASCII_NUM))) {
                             // 1. If the next data sequence is at least 2 consecutive digits, encode the next two digits as a double digit in ASCII mode.
                             $cw[] = (intval(substr($data, $pos, 2)) + 130);
                             ++$cw_num;
@@ -715,7 +715,7 @@ class Datamatrix {
                                 ++$cw_num;
                             } else {
                                 // get new byte
-                                $chr = ord($data{($pos)});
+                                $chr = ord($data[($pos)]);
                                 ++$pos;
                                 if ($this->isCharMode($chr, ENC_ASCII_EXT)) {
                                     // 3. If the next data character is extended ASCII (greater than 127) encode it in ASCII mode first using the Upper Shift (value 235) character.
@@ -743,7 +743,7 @@ class Datamatrix {
                         $charset = $this->chset[$set_id];
                         do {
                             // 2. process the next character in C40 encodation.
-                            $chr = ord($data{($epos)});
+                            $chr = ord($data[($epos)]);
                             ++$epos;
                             // check for extended character
                             if ($chr & 0x80) {
@@ -839,7 +839,7 @@ class Datamatrix {
                         $field_lenght = 0;
                         while ($epos < $data_lenght) {
                             // 2. process the next character in EDIFACT encodation.
-                            $chr = ord($data{($epos)});
+                            $chr = ord($data[($epos)]);
                             ++$epos;
                             $temp_cw[] = $chr;
                             ++$field_lenght;
@@ -899,7 +899,7 @@ class Datamatrix {
                                 break; // exit from B256 mode
                             } else {
                                 // 2. Otherwise, process the next character in Base 256 encodation.
-                                $chr = ord($data{($pos)});
+                                $chr = ord($data[($pos)]);
                                 ++$pos;
                                 $temp_cw[] = $chr;
                                 ++$field_lenght;

--- a/src/Milon/Barcode/PDF417.php
+++ b/src/Milon/Barcode/PDF417.php
@@ -877,7 +877,7 @@ class PDF417 {
                     $txtarr = array(); // array of characters and sub-mode switching characters
                     $codelen = strlen($code);
                     for ($i = 0; $i < $codelen; ++$i) {
-                        $chval = ord($code{$i});
+                        $chval = ord($code[$i]);
                         if (($k = array_search($chval, $this->textsubmodes[$submode])) !== false) {
                             // we are on the same sub-mode
                             $txtarr[] = $k;
@@ -887,7 +887,7 @@ class PDF417 {
                                 // search new sub-mode
                                 if (($s != $submode) AND (($k = array_search($chval, $this->textsubmodes[$s])) !== false)) {
                                     // $s is the new submode
-                                    if (((($i + 1) == $codelen) OR ((($i + 1) < $codelen) AND (array_search(ord($code{($i + 1)}), $this->textsubmodes[$submode]) !== false))) AND (($s == 3) OR (($s == 0) AND ($submode == 1)))) {
+                                    if (((($i + 1) == $codelen) OR ((($i + 1) < $codelen) AND (array_search(ord($code[($i + 1)]), $this->textsubmodes[$submode]) !== false))) AND (($s == 3) OR (($s == 0) AND ($submode == 1)))) {
                                         // shift (temporary change only for this char)
                                         if ($s == 3) {
                                             // shift to puntuaction
@@ -933,12 +933,12 @@ class PDF417 {
                             $sublen = strlen($code);
                         }
                         if ($sublen == 6) {
-                            $t = bcmul('' . ord($code{0}), '1099511627776');
-                            $t = bcadd($t, bcmul('' . ord($code{1}), '4294967296'));
-                            $t = bcadd($t, bcmul('' . ord($code{2}), '16777216'));
-                            $t = bcadd($t, bcmul('' . ord($code{3}), '65536'));
-                            $t = bcadd($t, bcmul('' . ord($code{4}), '256'));
-                            $t = bcadd($t, '' . ord($code{5}));
+                            $t = bcmul('' . ord($code[0]), '1099511627776');
+                            $t = bcadd($t, bcmul('' . ord($code[1]), '4294967296'));
+                            $t = bcadd($t, bcmul('' . ord($code[2]), '16777216'));
+                            $t = bcadd($t, bcmul('' . ord($code[3]), '65536'));
+                            $t = bcadd($t, bcmul('' . ord($code[4]), '256'));
+                            $t = bcadd($t, '' . ord($code[5]));
                             do {
                                 $d = bcmod($t, '900');
                                 $t = bcdiv($t, '900');
@@ -946,7 +946,7 @@ class PDF417 {
                             } while ($t != '0');
                         } else {
                             for ($i = 0; $i < $sublen; ++$i) {
-                                $cw[] = ord($code{$i});
+                                $cw[] = ord($code[$i]);
                             }
                         }
                         $code = $rest;


### PR DESCRIPTION
This PR replaces the deprecated curly brace syntax for array and string access to version-6.