### PR TITLE
Fix 2D for non Laravel projects

### DIFF
--- a/src/Milon/Barcode/DNS2D.php
+++ b/src/Milon/Barcode/DNS2D.php
@@ -405,7 +405,7 @@ class DNS2D {
         return $path;
     }
 
-    protected function setStorPath($path) {
+    public function setStorPath($path) {
         $this->store_path = rtrim($path, '/' . DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         return $this;
     }


### PR DESCRIPTION
Following up on PR #134, I changed `setStorPath()` in `DNS2D::class` as well, to allow usage in non-Laravel projects.