### PR TITLE
Fix error 2d barcodes PNG squares were being generated 1px too wide

### DIFF
--- a/src/Milon/Barcode/DNS2D.php
+++ b/src/Milon/Barcode/DNS2D.php
@@ -215,9 +215,9 @@ class DNS2D {
                 if ($this->barcode_array['bcode'][$r][$c] == 1) {
                     // draw a single barcode cell
                     if ($imagick) {
-                        $bar->rectangle($x, $y, ($x + $w), ($y + $h));
+                        $bar->rectangle($x, $y, ($x + ($w-1)), ($y + ($h-1)));
                     } else {
-                        imagefilledrectangle($png, $x, $y, ($x + $w), ($y + $h), $fgcol);
+                        imagefilledrectangle($png, $x, $y, ($x + ($w-1)), ($y + ($h-1)), $fgcol);
                     }
                 }
                 $x += $w;


### PR DESCRIPTION
Fix error where PNG squares on 2d barcodes were being generated one pixel too wide.

There was and 'off by one' error in PNG algorithm:

https://en.wikipedia.org/wiki/Off-by-one_error

This fixes it.

The end result of this was that the corner of one square would bleed into another - havoc when printing.

This was especially important for smaller images / lower square sizes, but wouldn't have been noticeable at higher resolutions.

![image](https://user-images.githubusercontent.com/3750419/172592217-857c5138-35e4-4051-911e-72f31a2ef6c5.png)

![image](https://user-images.githubusercontent.com/3750419/172592255-becf4ad1-5b4c-4b7c-a36e-1bbbfc560594.png)

![image](https://user-images.githubusercontent.com/3750419/172592348-56b492aa-db7d-41a5-badf-589012bc85b4.png)
