### PR TITLE
Avoid exception `rtrim() Passing null to parameter #1`

### DIFF
--- a/src/Milon/Barcode/DNS2D.php
+++ b/src/Milon/Barcode/DNS2D.php
@@ -406,7 +406,7 @@ class DNS2D {
     }
 
     public function setStorPath($path) {
-        $this->store_path = rtrim($path, '/' . DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $this->store_path = rtrim((string) $path, '/' . DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         return $this;
     }
 


### PR DESCRIPTION
If there is no config, and it is not needed pops up an exception on PHP 8.1, 8.2