### PR TITLE
types: address DNS2D incorrect return types in docblock comments

### DIFF
--- a/src/Milon/Barcode/DNS2D.php
+++ b/src/Milon/Barcode/DNS2D.php
@@ -175,7 +175,7 @@ class DNS2D {
      * @param $w (int) Width of a single rectangle element in pixels.
      * @param $h (int) Height of a single rectangle element in pixels.
      * @param $color (array) RGB (0-255) foreground color for bar elements (background is transparent).
-     * @return path or false in case of error.
+     * @return string|false path or false in case of error.
      * @protected
      */
     public function getBarcodePNG($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {
@@ -247,7 +247,7 @@ class DNS2D {
      * @param $w (int) Width of a single bar element in pixels.
      * @param $h (int) Height of a single bar element in pixels.
      * @param $color (array) RGB (0-255) foreground color for bar elements (background is transparent).
-     * @return url or false in case of error.
+     * @return string|false url or false in case of error.
      * @protected
      */
     protected function getBarcodePNGUri($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {
@@ -267,7 +267,7 @@ class DNS2D {
      * @param $w (int) Width of a single rectangle element in pixels.
      * @param $h (int) Height of a single rectangle element in pixels.
      * @param $color (array) RGB (0-255) foreground color for bar elements (background is transparent).
-     * @return path of image whice created
+     * @return string|false path of image which was created or false in case of error
      * @protected
      */
     protected function getBarcodePNGPath($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {


### PR DESCRIPTION
Hello 👋 

When running psalm static analysis, the following error was flagged when utilizing the getBarcodePNG function:
https://psalm.dev/docs/running_psalm/issues/UndefinedDocblockClass/

This addresses that and cleans up a few other return types. Let me know if there's anything else you'd like me to add in this change or other processes you'd prefer to be followed.