### PR TITLE
Set GD extension as required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     ],
     "require": {
         "php": "^7.3 | ^8.0",
+        "ext-gd": "*"
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0 | ^11.0"
     },
     "autoload": {


### PR DESCRIPTION
It will be nice to receive an error message if the extension is not installed. I lost an hour trying to figure out why it's not working, but this seems like a simple fix. 