### PR TITLE
Fix float to int loses precision notice on QR

### DIFF
--- a/src/Milon/Barcode/QRcode.php
+++ b/src/Milon/Barcode/QRcode.php
@@ -871,11 +871,11 @@ class QRcode {
             if ($col >= $this->rsblocks[0]['dataLength']) {
                 $row += $this->b1;
             }
-            $ret = $this->rsblocks[$row]['data'][$col];
+            $ret = $this->rsblocks[floor($row)]['data'][floor($col)];
         } elseif ($this->count < $this->dataLength + $this->eccLength) {
             $row = ($this->count - $this->dataLength) % $this->blocks;
             $col = ($this->count - $this->dataLength) / $this->blocks;
-            $ret = $this->rsblocks[$row]['ecc'][$col];
+            $ret = $this->rsblocks[floor($row)]['ecc'][floor($col)];
         } else {
             return 0;
         }


### PR DESCRIPTION
- Closes #201
- Closes #200
- Closes #154

```
Implicit conversion from float 16.5 to int loses precision 
    on vendor/milon/barcode/src/Milon/Barcode/QRcode.php:874 
Implicit conversion from float 3.5 to int loses precision 
    on vendor/milon/barcode/src/Milon/Barcode/QRcode.php:878 
```