### PR TITLE
Support background color, transparent as default

### DIFF
--- a/src/Milon/Barcode/DNS2D.php
+++ b/src/Milon/Barcode/DNS2D.php
@@ -174,11 +174,12 @@ class DNS2D {
      * @param $type (string) type of barcode: <ul><li>DATAMATRIX : Datamatrix (ISO/IEC 16022)</li><li>PDF417 : PDF417 (ISO/IEC 15438:2006)</li><li>PDF417,a,e,t,s,f,o0,o1,o2,o3,o4,o5,o6 : PDF417 with parameters: a = aspect ratio (width/height); e = error correction level (0-8); t = total number of macro segments; s = macro segment index (0-99998); f = file ID; o0 = File Name (text); o1 = Segment Count (numeric); o2 = Time Stamp (numeric); o3 = Sender (text); o4 = Addressee (text); o5 = File Size (numeric); o6 = Checksum (numeric). NOTES: Parameters t, s and f are required for a Macro Control Block, all other parametrs are optional. To use a comma character ',' on text options, replace it with the character 255: "\xff".</li><li>QRCODE : QRcode Low error correction</li><li>QRCODE,L : QRcode Low error correction</li><li>QRCODE,M : QRcode Medium error correction</li><li>QRCODE,Q : QRcode Better error correction</li><li>QRCODE,H : QR-CODE Best error correction</li><li>RAW: raw mode - comma-separad list of array rows</li><li>RAW2: raw mode - array rows are surrounded by square parenthesis.</li><li>TEST : Test matrix</li></ul>
      * @param $w (int) Width of a single rectangle element in pixels.
      * @param $h (int) Height of a single rectangle element in pixels.
-     * @param $color (array) RGB (0-255) foreground color for bar elements (background is transparent).
+     * @param $color (array) RGB (0-255) foreground color for bar elements.
+     * @param $bgcolor (array) RGB (0-255) background color (transparent as default).
      * @return string|false path or false in case of error.
      * @protected
      */
-    public function getBarcodePNG($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {
+    public function getBarcodePNG($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0), $bgcolor = null) {
         if (!$this->store_path) {
             $this->setStorPath(app('config')->get("barcode.store_path"));
         }
@@ -191,15 +192,17 @@ class DNS2D {
             // GD library
             $imagick = false;
             $png = imagecreate($width, $height);
-            $bgcol = imagecolorallocate($png, 255, 255, 255);
-            imagecolortransparent($png, $bgcol);
+            $bgcol = imagecolorallocate($png, ...($bgcolor ?: [255, 255, 255]));
+            if (!$bgcolor) {
+                imagecolortransparent($png, $bgcol);
+            }
             $fgcol = imagecolorallocate($png, $color[0], $color[1], $color[2]);
         } elseif (extension_loaded('imagick')) {
             $imagick = true;
-            $bgcol = new \imagickpixel('rgb(255,255,255');
+            $bgcol = new \imagickpixel('rgb(' . implode(',', $bgcolor ?: [255, 255, 255]) . ')');
             $fgcol = new \imagickpixel('rgb(' . $color[0] . ',' . $color[1] . ',' . $color[2] . ')');
             $png = new \Imagick();
-            $png->newImage($width, $height, 'none', 'png');
+            $png->newImage($width, $height, !$bgcolor? 'none' : $bgcol, 'png');
             $bar = new \imagickdraw();
             $bar->setfillcolor($fgcol);
         } else {
@@ -266,11 +269,12 @@ class DNS2D {
      * @param $type (string) type of barcode: <ul><li>DATAMATRIX : Datamatrix (ISO/IEC 16022)</li><li>PDF417 : PDF417 (ISO/IEC 15438:2006)</li><li>PDF417,a,e,t,s,f,o0,o1,o2,o3,o4,o5,o6 : PDF417 with parameters: a = aspect ratio (width/height); e = error correction level (0-8); t = total number of macro segments; s = macro segment index (0-99998); f = file ID; o0 = File Name (text); o1 = Segment Count (numeric); o2 = Time Stamp (numeric); o3 = Sender (text); o4 = Addressee (text); o5 = File Size (numeric); o6 = Checksum (numeric). NOTES: Parameters t, s and f are required for a Macro Control Block, all other parametrs are optional. To use a comma character ',' on text options, replace it with the character 255: "\xff".</li><li>QRCODE : QRcode Low error correction</li><li>QRCODE,L : QRcode Low error correction</li><li>QRCODE,M : QRcode Medium error correction</li><li>QRCODE,Q : QRcode Better error correction</li><li>QRCODE,H : QR-CODE Best error correction</li><li>RAW: raw mode - comma-separad list of array rows</li><li>RAW2: raw mode - array rows are surrounded by square parenthesis.</li><li>TEST : Test matrix</li></ul>
      * @param $w (int) Width of a single rectangle element in pixels.
      * @param $h (int) Height of a single rectangle element in pixels.
-     * @param $color (array) RGB (0-255) foreground color for bar elements (background is transparent).
+     * @param $color (array) RGB (0-255) foreground color for bar elements.
+     * @param $bgcolor (array) RGB (0-255) background color (transparent as default).
      * @return string|false path of image which was created or false in case of error
      * @protected
      */
-    protected function getBarcodePNGPath($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0)) {
+    protected function getBarcodePNGPath($code, $type, $w = 3, $h = 3, $color = array(0, 0, 0), $bgcolor = null) {
         if (!$this->store_path) {
             $this->setStorPath(app('config')->get("barcode.store_path"));
         }
@@ -283,15 +287,17 @@ class DNS2D {
             // GD library
             $imagick = false;
             $png = imagecreate($width, $height);
-            $bgcol = imagecolorallocate($png, 255, 255, 255);
-            imagecolortransparent($png, $bgcol);
+            $bgcol = imagecolorallocate($png, ...($bgcolor ?: [255, 255, 255]));
+            if (!$bgcolor) {
+                imagecolortransparent($png, $bgcol);
+            }
             $fgcol = imagecolorallocate($png, $color[0], $color[1], $color[2]);
         } elseif (extension_loaded('imagick')) {
             $imagick = true;
-            $bgcol = new imagickpixel('rgb(255,255,255');
+            $bgcol = new imagickpixel('rgb(' . implode(',', $bgcolor ?: [255, 255, 255]) . ')');
             $fgcol = new imagickpixel('rgb(' . $color[0] . ',' . $color[1] . ',' . $color[2] . ')');
             $png = new Imagick();
-            $png->newImage($width, $height, 'none', 'png');
+            $png->newImage($width, $height, !$bgcolor ? 'none' : $bgcol, 'png');
             $bar = new imagickdraw();
             $bar->setfillcolor($fgcol);
         } else {

--- a/src/Milon/Barcode/Facades/DNS2DFacade.php
+++ b/src/Milon/Barcode/Facades/DNS2DFacade.php
@@ -7,8 +7,8 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static string getBarcodeSVG(string $code, string $type, int $w = 3, int $h = 3, string $color = 'black')
  * @method static string getBarcodeHTML(string $code, string $type, int $w = 10, int $h = 10, string $color = 'black')
- * @method static string|false getBarcodePNG(string $code, string $type, int $w = 3, int $h = 3, array $color = [0, 0, 0],)
- * @method static string|false getBarcodePNGPath(string $code, string $type, int $w = 2, int $h = 30, array $color = [0, 0, 0])
+ * @method static string|false getBarcodePNG(string $code, string $type, int $w = 3, int $h = 3, array $color = [0, 0, 0], ?array $bgcolor = null)
+ * @method static string|false getBarcodePNGPath(string $code, string $type, int $w = 2, int $h = 30, array $color = [0, 0, 0], ?array $bgcolor = null)
  * @method static \Milon\Barcode\DNS2D setStorPath(string $path)
  */
 class DNS2DFacade extends Facade


### PR DESCRIPTION
- Closes #203

```php
echo '<img src="data:image/png;base64,'
    . \DNS2D::getBarcodePNG('TEXT VALUE', 'QRCODE', bgcolor:[255,200,0])
    . '" alt="barcode"   />';
```

<img width="77" height="81" alt="image" src="https://github.com/user-attachments/assets/65236f3f-6736-47af-b627-7cfbfbc0456d" />



