### PR TITLE
Avoid deprecated GD image cleanup calls on PHP 8.5

### DIFF
--- a/src/Milon/Barcode/DNS1D.php
+++ b/src/Milon/Barcode/DNS1D.php
@@ -235,7 +235,9 @@ class DNS1D {
             echo $png;
         } else {
             imagepng($png);
-            imagedestroy($png);
+            if (is_resource($png)) {
+                imagedestroy($png);
+            }
         }
         $image = ob_get_clean();
         $image = base64_encode($image);
@@ -326,10 +328,14 @@ class DNS1D {
             //echo $png;
         }
         if (ImagePng($png, $save_file)) {
-            imagedestroy($png);
+            if (is_resource($png)) {
+                imagedestroy($png);
+            }
             return str_replace(public_path(), '', $save_file);
         } else {
-            imagedestroy($png);
+            if (is_resource($png)) {
+                imagedestroy($png);
+            }
             return $code;
         }
     }
@@ -2700,7 +2706,9 @@ class DNS1D {
             echo $jpg;
         } else {
             imagejpeg($jpg);
-            imagedestroy($jpg);
+            if (is_resource($jpg)) {
+                imagedestroy($jpg);
+            }
         }
         $image = ob_get_clean();
         $image = base64_encode($image);
@@ -2782,10 +2790,14 @@ class DNS1D {
             //echo $jpg;
         }
         if (imagejpeg($jpg, $save_file)) {
-            imagedestroy($jpg);
+            if (is_resource($jpg)) {
+                imagedestroy($jpg);
+            }
             return str_replace(public_path(), '', $save_file);
         } else {
-            imagedestroy($jpg);
+            if (is_resource($jpg)) {
+                imagedestroy($jpg);
+            }
             return $code;
         }
     }

--- a/src/Milon/Barcode/DNS2D.php
+++ b/src/Milon/Barcode/DNS2D.php
@@ -235,7 +235,9 @@ class DNS2D {
             echo $png;
         } else {
             imagepng($png);
-            imagedestroy($png);
+            if (is_resource($png)) {
+                imagedestroy($png);
+            }
         }
         $image = ob_get_clean();
         $image = base64_encode($image);
@@ -330,10 +332,14 @@ class DNS2D {
             //echo $png;
         }
         if (ImagePng($png, $save_file)) {
-            imagedestroy($png);
+            if (is_resource($png)) {
+                imagedestroy($png);
+            }
             return str_replace(public_path(), '', $save_file);
         } else {
-            imagedestroy($png);
+            if (is_resource($png)) {
+                imagedestroy($png);
+            }
             return $code;
         }
     }

--- a/tests/DeprecationCompatibilityTest.php
+++ b/tests/DeprecationCompatibilityTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Milon\Barcode;
+
+function public_path()
+{
+    return sys_get_temp_dir();
+}
+
+namespace Milon\Barcode\Tests;
+
+use Milon\Barcode\DNS1D;
+use Milon\Barcode\DNS2D;
+use PHPUnit\Framework\TestCase;
+
+class DeprecationCompatibilityTest extends TestCase
+{
+    public function testDns1dBarcodeGenerationDoesNotTriggerDeprecations(): void
+    {
+        $dns1d = new DNS1D();
+        $dns1d->setStorPath($this->temporaryStoragePath());
+
+        list($pngBarcode, $pngDeprecations) = $this->captureDeprecations(function () use ($dns1d) {
+            return $dns1d->getBarcodePNG('123456789012', 'C128');
+        });
+
+        $this->assertNotFalse($pngBarcode);
+        $this->assertSame(array(), $pngDeprecations);
+
+        list($jpgBarcode, $jpgDeprecations) = $this->captureDeprecations(function () use ($dns1d) {
+            return $dns1d->getBarcodeJPG('123456789012', 'C128');
+        });
+
+        $this->assertNotFalse($jpgBarcode);
+        $this->assertSame(array(), $jpgDeprecations);
+
+        list($pngPath, $pngPathDeprecations) = $this->captureDeprecations(function () use ($dns1d) {
+            return $dns1d->getBarcodePNGPath('123456789012', 'C128');
+        });
+
+        $this->assertStringEndsWith('.png', $pngPath);
+        $this->assertFileExists($this->toAbsoluteTempPath($pngPath));
+        unlink($this->toAbsoluteTempPath($pngPath));
+        $this->assertSame(array(), $pngPathDeprecations);
+
+        list($jpgPath, $jpgPathDeprecations) = $this->captureDeprecations(function () use ($dns1d) {
+            return $dns1d->getBarcodeJPGPath('123456789012', 'C128');
+        });
+
+        $this->assertStringEndsWith('.jpg', $jpgPath);
+        $this->assertFileExists($this->toAbsoluteTempPath($jpgPath));
+        unlink($this->toAbsoluteTempPath($jpgPath));
+        $this->assertSame(array(), $jpgPathDeprecations);
+    }
+
+    public function testDns2dBarcodeGenerationDoesNotTriggerDeprecations(): void
+    {
+        $dns2d = new DNS2D();
+        $dns2d->setStorPath($this->temporaryStoragePath());
+
+        list($pngBarcode, $pngDeprecations) = $this->captureDeprecations(function () use ($dns2d) {
+            return $dns2d->getBarcodePNG('https://example.com', 'QRCODE');
+        });
+
+        $this->assertNotFalse($pngBarcode);
+        $this->assertSame(array(), $pngDeprecations);
+
+        list($pngPath, $pngPathDeprecations) = $this->captureDeprecations(function () use ($dns2d) {
+            return $dns2d->getBarcodePNGPath('https://example.com', 'QRCODE');
+        });
+
+        $this->assertStringEndsWith('.png', $pngPath);
+        $this->assertFileExists($this->toAbsoluteTempPath($pngPath));
+        unlink($this->toAbsoluteTempPath($pngPath));
+        $this->assertSame(array(), $pngPathDeprecations);
+    }
+
+    private function captureDeprecations(callable $callback): array
+    {
+        $deprecations = array();
+
+        set_error_handler(function ($severity, $message) use (&$deprecations) {
+            if ($severity === E_DEPRECATED || $severity === E_USER_DEPRECATED) {
+                $deprecations[] = $message;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            $result = $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return array($result, $deprecations);
+    }
+
+    private function toAbsoluteTempPath(string $relativePath): string
+    {
+        return rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($relativePath, '/\\');
+    }
+
+    private function temporaryStoragePath(): string
+    {
+        return rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+    }
+}


### PR DESCRIPTION
This PR prevents PHP 8.5 deprecation warnings caused by legacy imagedestroy() calls in barcode image generation. 

The fix is intentionally backwards compatible with the package's declared composer.json requirements (php ^7.3 | ^8.0), by only calling imagedestroy() when the GD handle is still a resource on older PHP versions.

An alternative would have been to remove imagedestroy() entirely, which would also silence the warning on PHP 8.5, but this change deliberately preserves the legacy cleanup behavior for older supported PHP versions instead of adopting a PHP-8-only style solution.